### PR TITLE
Paralell build and working Mingw64 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 sudo: false
 language: cpp
-stages: 
-  - Test
-  - Osx-build-2
 jobs:
   include:
     - os: linux
@@ -25,55 +22,14 @@ jobs:
         - cd automake-1.15; ./configure -q --prefix=/usr && make V=0; sudo make V=0 install; cd ..; rm -fR automake-1.15
         - echo -e "travis_fold:end:install-automake"
         - cd $TRAVIS_BUILD_DIR
-        - make info-start
-        - make build-bins
-        - travis_wait 25 make build-gcc-1
-        - make build-newlib
-        - travis_wait 35 make build-gcc-2
-        - make build-libhal
-        - make build-sdk-libs
-        - travis_wait 15 make build-tools
-        - make distrib
+        - travis_wait 45 make -j3
       cache: false
     - os: osx
       script:
         - cd $TRAVIS_BUILD_DIR
-        - make info-start
-        - make build-bins
-        - travis_wait 25 make build-gcc-1
-        - make build-newlib
-        - make get-gcc-src-dir #prefetch for Osx-build-2
-      cache:
-        timeout: 2000
-        directories:
-          - comp_libs/
-          - src/
-          - xtensa-lx106-elf/
-          - tarballs/
-      deploy: false
-    - stage: Osx-build-2
-      os: osx
-      script:
-        - cd $TRAVIS_BUILD_DIR
-        - ls -la src tarballs
-        - mkdir -p distrib # needed for log-files
-        - travis_wait 45 make build-gcc-2
-        - make build-libhal
-        - make build-sdk-libs
-        - travis_wait 15 make build-tools
-        - make distrib
-        - ls -la src tarballs
-      before_cache: # caching is after the script
-        # so we don't need them to delete
-        - mv comp_libs comp_old
-        - mv src src_old
-      cache:
-        timeout: 2000
-        directories:
-          - comp_libs/
-          - src/
-          - xtensa-lx106-elf/
-          - tarballs/
+        - travis_wait 45 make -j3
+      cache: false
+
 before_install:
   # unset is needed for libhal
   - test -n $CC  && unset CC

--- a/Makefile
+++ b/Makefile
@@ -463,11 +463,8 @@ all:
 	@$(MAKE) info-start
 	@$(MAKE) info-build
 	@$(MAKE) build-bins 2>>$(ERROR_LOG)
-	@$(MAKE) build-gcc-1 2>>$(ERROR_LOG)
-	@$(MAKE) build-$(NLX) 2>>$(ERROR_LOG)
-	@$(MAKE) build-gcc-2 2>>$(ERROR_LOG)
-	@$(MAKE) build-$(HAL) 2>>$(ERROR_LOG)
-	@$(MAKE) build-tools 2>>$(ERROR_LOG)
+	@$(MAKE) build 2>>$(ERROR_LOG)
+	@$(MAKE) compress 2>>$(ERROR_LOG)
 	@$(MAKE) build-sdk-libs 2>>$(ERROR_LOG)
 	@$(MAKE) info
 	@cat build-start.txt; rm build-start.txt
@@ -484,12 +481,20 @@ install:
 #************* single builds ***************
 #*******************************************
 
-build: build-bins build-$(GCC)-1 build-$(NLX) build-$(GCC)-2 build-$(HAL) build-sdk-libs
-build-bins: build-$(CURSES) build-$(GMP) build-$(MPFR) build-$(ISL) build-$(CLOOG) build-$(MPC) build-$(EXPAT) build-$(BIN)
-###build-sdk: build-$(SDK) build-sdk-libs
-###build-sdk: build-sdk-libs
-build-tools: build-$(GDB) build-$(LWIP) distrib #strip compress
+build:
+	$(MAKE) build-$(GCC)-1 
+	$(MAKE) build-$(NLX) 
+	$(MAKE) build-$(GCC)-2 
+	$(MAKE) build-$(HAL) 
+	$(MAKE) build-sdk-libs
 
+build-bins: build-$(GMP) build-$(MPFR) build-$(ISL) build-$(CLOOG) build-$(MPC) build-$(BIN)
+build-tools:
+	$(MAKE) build-$(GDB) 
+	$(MAKE) build-$(LWIP)
+	$(MAKE) build-$(EXPAT) 
+	$(MAKE) build-$(CURSES)
+	
 # prefetch for travis Osx-build-2
 get-gcc-src-dir:
 	$(MAKE) $(SOURCE_DIR)/.$(GCC).extracted

--- a/Makefile
+++ b/Makefile
@@ -21,17 +21,17 @@ USE_STRIP = y
 # compress:	reduces used disc space by approx. 40-50 percent
 USE_COMPRESS = n
 # The Curses library "cursor optimization"
-USE_CURSES = n
+USE_CURSES = y
 # build lwip-lib
-USE_LWIP = n
+USE_LWIP = y
 # build isl
 USE_ISL = n
 # XML-Parser
-USE_EXPAT = n
+USE_EXPAT = y
 # The Chunky Loop Generator
 USE_CLOOG = n
 # build debugger
-USE_GDB = n
+USE_GDB = y
 
 BUILDPATH = /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:
 

--- a/Makefile
+++ b/Makefile
@@ -821,7 +821,7 @@ define Build_Modul
 	@echo "##########################"
 	@echo "#### Build $1..."
 	#### Build: Path=$(SAFEPATH); $3 $(MAKE) $4 -C $2
-	PATH=$(SAFEPATH); $3 $(MAKE) $4 -C $2 $(QUIET) 
+	+PATH=$(SAFEPATH); $3 $(MAKE) $4 -C $2 $(QUIET) 
 	@touch $(SOURCE_DIR)/.$1.builded
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -496,32 +496,32 @@ get-gcc-src-dir:
 
 get-tars: $(TAR_DIR) get-$(CURSES) $(GMP_TAR) $(MPFR_TAR) get-$(ISL) get-$(CLOOG) $(MPC_TAR) get-$(EXPAT) $(BIN_TAR) $(GCC_TAR) $(NLX_TAR) $(HAL_TAR) if_isl_tar if_cloog_tar if_lwip_tar if_gdb_tar
 
-get-$(CURSES): $(TAR_DIR)
+get-$(CURSES):
 ifeq ($(USE_CURSES),y)
 	$(MAKE) $(CURSES_TAR)
 endif
 
-get-$(ISL): $(TAR_DIR)
+get-$(ISL):
 ifeq ($(USE_ISL),y)
 	$(MAKE) $(ISL_TAR)
 endif
 
-get-$(CLOOG): $(TAR_DIR)
+get-$(CLOOG):
 ifeq ($(USE_CLOOG),y)
 	$(MAKE) $(CLOOG_TAR)
 endif
 
-get-$(EXPAT): $(TAR_DIR)
+get-$(EXPAT):
 ifeq ($(USE_EXPAT),y)
 	$(MAKE) $(EXPAT_TAR)
 endif
 
-get-$(GDB): $(TAR_DIR)
+get-$(GDB):
 ifeq ($(USE_GDB),y)
 	$(MAKE) $(GDB_TAR)
 endif
 
-get-$(LWIP): $(TAR_DIR)
+get-$(LWIP):
 ifeq ($(USE_LWIP),y)
 	$(MAKE) $(LWIP_TAR)
 endif
@@ -716,7 +716,7 @@ ifeq ($(USE_DISTRIB),y)
 	@ls $(DIST_DIR)/$(DISTRIB)*
 	@touch $@
 endif
-$(SOURCE_DIR)/.$(SDK).loaded: $(TAR_DIR)
+$(SOURCE_DIR)/.$(SDK).loaded:
 	$(call Load_Modul,$(SDK),$(SDK_URL),$(SDK_TAR))
 $(SOURCE_DIR)/.$(SDK).extracted: $(SOURCE_DIR)/.$(SDK).loaded
 	$(call Extract_Modul,$(SDK),$(TOP_SDK)/$(SDK_VER),$(SDK_TAR),$(TOP_SDK)/$(SDK_TAR_DIR))
@@ -838,7 +838,7 @@ define Install_Modul
 endef
 
 #************** CURSES
-$(SOURCE_DIR)/.$(CURSES).loaded: $(TAR_DIR)
+$(SOURCE_DIR)/.$(CURSES).loaded:
 	$(call Load_Modul,$(CURSES),$(CURSES_URL),$(CURSES_TAR))
 $(SOURCE_DIR)/.$(CURSES).extracted: $(SOURCE_DIR)/.$(CURSES).loaded
 	$(call Extract_Modul,$(CURSES),$(CURSES_DIR),$(CURSES_TAR),$(CURSES_DIR)/$(CURSES_TAR_DIR))
@@ -850,7 +850,7 @@ $(SOURCE_DIR)/.$(CURSES).installed: $(SOURCE_DIR)/.$(CURSES).builded
 	$(call Install_Modul,$(CURSES),$(BUILD_CURSES_DIR),$(INST_OPT))
 
 #************** GMP (GNU Multiple Precision Arithmetic Library)
-$(SOURCE_DIR)/.$(GMP).loaded: $(TAR_DIR)
+$(SOURCE_DIR)/.$(GMP).loaded:
 	$(call Load_Modul,$(GMP),$(GMP_URL),$(GMP_TAR))
 $(SOURCE_DIR)/.$(GMP).extracted: $(SOURCE_DIR)/.$(GMP).loaded
 	$(call Extract_Modul,$(GMP),$(GMP_DIR),$(GMP_TAR),$(GMP_DIR)/$(GMP_TAR_DIR))
@@ -862,7 +862,7 @@ $(SOURCE_DIR)/.$(GMP).installed: $(SOURCE_DIR)/.$(GMP).builded
 	$(call Install_Modul,$(GMP),$(BUILD_GMP_DIR),$(INST_OPT))
 
 #************** MPFR (Multiple Precision Floating-Point Reliable Library)
-$(SOURCE_DIR)/.$(MPFR).loaded: $(TAR_DIR)
+$(SOURCE_DIR)/.$(MPFR).loaded:
 	$(call Load_Modul,$(MPFR),$(MPFR_URL),$(MPFR_TAR))
 $(SOURCE_DIR)/.$(MPFR).extracted: $(SOURCE_DIR)/.$(MPFR).loaded
 	$(call Extract_Modul,$(MPFR),$(MPFR_DIR),$(MPFR_TAR),$(MPFR_DIR)/$(MPFR_TAR_DIR))
@@ -874,7 +874,7 @@ $(SOURCE_DIR)/.$(MPFR).installed: $(SOURCE_DIR)/.$(MPFR).builded
 	$(call Install_Modul,$(MPFR),$(BUILD_MPFR_DIR),$(INST_OPT))
 
 #************** MPC (Multiple precision complex arithmetic Library)
-$(SOURCE_DIR)/.$(MPC).loaded: $(TAR_DIR)
+$(SOURCE_DIR)/.$(MPC).loaded:
 	$(call Load_Modul,$(MPC),$(MPC_URL),$(MPC_TAR))
 $(SOURCE_DIR)/.$(MPC).extracted: $(SOURCE_DIR)/.$(MPC).loaded
 	$(call Extract_Modul,$(MPC),$(MPC_DIR),$(MPC_TAR),$(MPC_DIR)/$(MPC_TAR_DIR))
@@ -886,7 +886,7 @@ $(SOURCE_DIR)/.$(MPC).installed: $(SOURCE_DIR)/.$(MPC).builded
 	$(call Install_Modul,$(MPC),$(BUILD_MPC_DIR),$(INST_OPT))
 
 #************** EXPAT
-$(SOURCE_DIR)/.$(EXPAT).loaded: $(TAR_DIR)
+$(SOURCE_DIR)/.$(EXPAT).loaded:
 	$(call Load_Modul,$(EXPAT),$(EXPAT_URL),$(EXPAT_TAR))
 $(SOURCE_DIR)/.$(EXPAT).extracted: $(SOURCE_DIR)/.$(EXPAT).loaded
 	$(call Extract_Modul,$(EXPAT),$(EXPAT_DIR),$(EXPAT_TAR),$(EXPAT_DIR)/$(EXPAT_TAR_DIR))
@@ -898,7 +898,7 @@ $(SOURCE_DIR)/.$(EXPAT).installed: $(SOURCE_DIR)/.$(EXPAT).builded
 	$(call Install_Modul,$(EXPAT),$(BUILD_EXPAT_DIR),$(INST_OPT))
 
 #************** Binutils (The GNU binary utilities)
-$(SOURCE_DIR)/.$(BIN).loaded: $(TAR_DIR)
+$(SOURCE_DIR)/.$(BIN).loaded:
 	$(call Load_Modul,$(BIN),$(BIN_URL),$(BIN_TAR))
 $(SOURCE_DIR)/.$(BIN).extracted: $(SOURCE_DIR)/.$(BIN).loaded
 	$(call Extract_Modul,$(BIN),$(BIN_DIR),$(BIN_TAR),$(BIN_DIR)/$(BIN_TAR_DIR))
@@ -910,7 +910,7 @@ $(SOURCE_DIR)/.$(BIN).installed: $(SOURCE_DIR)/.$(BIN).builded
 	$(call Install_Modul,$(BIN),$(BUILD_BIN_DIR),$(INST_OPT))
 
 #************** ISL
-$(SOURCE_DIR)/.$(ISL).loaded: $(TAR_DIR)
+$(SOURCE_DIR)/.$(ISL).loaded:
 	$(call Load_Modul,$(ISL),$(ISL_URL),$(ISL_TAR))
 $(SOURCE_DIR)/.$(ISL).extracted: $(SOURCE_DIR)/.$(ISL).loaded
 	$(call Extract_Modul,$(ISL),$(ISL_DIR),$(ISL_TAR),$(ISL_DIR)/$(ISL_TAR_DIR))
@@ -922,7 +922,7 @@ $(SOURCE_DIR)/.$(ISL).installed: $(SOURCE_DIR)/.$(ISL).builded
 	$(call Install_Modul,$(ISL),$(BUILD_ISL_DIR),$(INST_OPT))
 
 #************** CLooG
-$(SOURCE_DIR)/.$(CLOOG).loaded: $(TAR_DIR)
+$(SOURCE_DIR)/.$(CLOOG).loaded:
 	$(call Load_Modul,$(CLOOG),$(CLOOG_URL),$(CLOOG_TAR))
 $(SOURCE_DIR)/.$(CLOOG).extracted: $(SOURCE_DIR)/.$(CLOOG).loaded
 	$(call Extract_Modul,$(CLOOG),$(CLOOG_DIR),$(CLOOG_TAR),$(CLOOG_DIR)/$(CLOOG_TAR_DIR))
@@ -934,7 +934,7 @@ $(SOURCE_DIR)/.$(CLOOG).installed: $(SOURCE_DIR)/.$(CLOOG).builded
 	$(call Install_Modul,$(CLOOG),$(BUILD_CLOOG_DIR),$(INST_OPT))
 
 #************** GCC (The GNU C preprocessor)
-$(SOURCE_DIR)/.$(GCC).loaded: $(TAR_DIR)
+$(SOURCE_DIR)/.$(GCC).loaded:
 	$(call Load_Modul,$(GCC),$(GCC_URL),$(GCC_TAR))
 $(SOURCE_DIR)/.$(GCC).extracted: $(SOURCE_DIR)/.$(GCC).loaded
 	$(call Extract_Modul,$(GCC),$(GCC_DIR),$(GCC_TAR),$(GCC_DIR)/$(GCC_TAR_DIR))
@@ -959,7 +959,7 @@ $(SOURCE_DIR)/.$(GCC)-pass-2.installed: $(SOURCE_DIR)/.$(GCC)-pass-2.builded
 	$(call Install_Modul,$(GCC)-pass-2,$(BUILD_GCC_DIR)-pass-2,$(INST_OPT))
 
 #************** Newlib (ANSI C library, math library, and collection of board support packages)
-$(SOURCE_DIR)/.$(NLX).loaded: $(TAR_DIR)
+$(SOURCE_DIR)/.$(NLX).loaded:
 	$(call Load_Modul,$(NLX),$(NLX_URL),$(NLX_TAR))
 $(SOURCE_DIR)/.$(NLX).extracted: $(SOURCE_DIR)/.$(NLX).loaded
 	$(call Extract_Modul,$(NLX),$(NLX_DIR),$(NLX_TAR),$(NLX_DIR)/$(NLX_TAR_DIR))
@@ -972,7 +972,7 @@ $(SOURCE_DIR)/.$(NLX).installed: $(SOURCE_DIR)/.$(NLX).builded
 	$(call Install_Modul,$(NLX),$(BUILD_NLX_DIR),$(INST_OPT))
 
 #************** Libhal (Hardware Abstraction Library for Xtensa LX106)
-$(SOURCE_DIR)/.$(HAL).loaded: $(TAR_DIR)
+$(SOURCE_DIR)/.$(HAL).loaded:
 	$(call Load_Modul,$(HAL),$(HAL_URL),$(HAL_TAR))
 $(SOURCE_DIR)/.$(HAL).extracted: $(SOURCE_DIR)/.$(HAL).loaded
 	$(call Extract_Modul,$(HAL),$(HAL_DIR),$(HAL_TAR),$(HAL_DIR)/$(HAL_TAR_DIR))
@@ -985,7 +985,7 @@ $(SOURCE_DIR)/.$(HAL).installed: $(SOURCE_DIR)/.$(HAL).builded
 	$(call Install_Modul,$(HAL),$(BUILD_HAL_DIR),$(INST_OPT))
 
 #************** GDB (The GNU debugger)
-$(SOURCE_DIR)/.$(GDB).loaded: $(TAR_DIR)
+$(SOURCE_DIR)/.$(GDB).loaded:
 	$(call Load_Modul,$(GDB),$(GDB_URL),$(GDB_TAR))
 $(SOURCE_DIR)/.$(GDB).extracted: $(SOURCE_DIR)/.$(GDB).loaded
 	$(call Extract_Modul,$(GDB),$(GDB_DIR),$(GDB_TAR),$(GDB_DIR)/$(GDB_TAR_DIR))
@@ -997,7 +997,7 @@ $(SOURCE_DIR)/.$(GDB).installed: $(SOURCE_DIR)/.$(GDB).builded
 	$(call Install_Modul,$(GDB),$(BUILD_GDB_DIR),$(INST_OPT))
 
 #************** LWIP
-$(SOURCE_DIR)/.$(LWIP).loaded: $(TAR_DIR)
+$(SOURCE_DIR)/.$(LWIP).loaded:
 	$(call Load_Modul,$(LWIP),$(LWIP_URL),$(LWIP_TAR))
 $(SOURCE_DIR)/.$(LWIP).extracted: $(SOURCE_DIR)/.$(LWIP).loaded
 	$(call Extract_Modul,$(LWIP),$(LWIP_DIR),$(LWIP_TAR),$(LWIP_DIR)/$(LWIP_TAR_DIR))

--- a/Makefile
+++ b/Makefile
@@ -334,7 +334,6 @@ ifeq ($(DEBUG),y)
 	RMDIR    := rm -R -f
 	MOVE     := mv -f
 	UNTAR    := bsdtar -vxf
-	MAKE_OPT := $(MAKE)
 	CONF_OPT := configure
 	INST_OPT := install
 	AR_DEL   := dv
@@ -352,8 +351,6 @@ else
 	RMDIR    := rm -R -f
 	MOVE     := mv -f
 	UNTAR    := bsdtar -xf
-	#MAKE_OPT := make -s -j1
-	MAKE_OPT := $(MAKE) V=1 -s
 	CONF_OPT := configure -q
 	INST_OPT := install -s
 	AR_DEL   := d
@@ -463,25 +460,25 @@ SDK_TAR_DIR = $(SDK_VER)/$(SDK_ZIP)
 
 # splitted builds to prevent Travis from from assuming a stalled build
 all:
-	@$(MAKE_OPT) info-start
-	@$(MAKE_OPT) info-build
-	@$(MAKE_OPT) build-bins 2>>$(ERROR_LOG)
-	@$(MAKE_OPT) build-gcc-1 2>>$(ERROR_LOG)
-	@$(MAKE_OPT) build-$(NLX) 2>>$(ERROR_LOG)
-	@$(MAKE_OPT) build-gcc-2 2>>$(ERROR_LOG)
-	@$(MAKE_OPT) build-$(HAL) 2>>$(ERROR_LOG)
-	@$(MAKE_OPT) build-tools 2>>$(ERROR_LOG)
-	@$(MAKE_OPT) build-sdk-libs 2>>$(ERROR_LOG)
-	@$(MAKE_OPT) info
+	@$(MAKE) info-start
+	@$(MAKE) info-build
+	@$(MAKE) build-bins 2>>$(ERROR_LOG)
+	@$(MAKE) build-gcc-1 2>>$(ERROR_LOG)
+	@$(MAKE) build-$(NLX) 2>>$(ERROR_LOG)
+	@$(MAKE) build-gcc-2 2>>$(ERROR_LOG)
+	@$(MAKE) build-$(HAL) 2>>$(ERROR_LOG)
+	@$(MAKE) build-tools 2>>$(ERROR_LOG)
+	@$(MAKE) build-sdk-libs 2>>$(ERROR_LOG)
+	@$(MAKE) info
 	@cat build-start.txt; rm build-start.txt
-	@$(MAKE_OPT) distrib
+	@$(MAKE) distrib
 	@$(OUTPUT_DATE)
 	@echo -e "\07"
 
 install:
 	rm $(SOURCE_DIR)/.*.installed
-	make info-install
-	make all
+	$(MAKE) info-install
+	$(MAKE) all
 
 #*******************************************
 #************* single builds ***************
@@ -495,38 +492,38 @@ build-tools: build-$(GDB) build-$(LWIP) distrib #strip compress
 
 # prefetch for travis Osx-build-2
 get-gcc-src-dir:
-	make $(SOURCE_DIR)/.$(GCC).extracted
+	$(MAKE) $(SOURCE_DIR)/.$(GCC).extracted
 
 get-tars: $(TAR_DIR) get-$(CURSES) $(GMP_TAR) $(MPFR_TAR) get-$(ISL) get-$(CLOOG) $(MPC_TAR) get-$(EXPAT) $(BIN_TAR) $(GCC_TAR) $(NLX_TAR) $(HAL_TAR) if_isl_tar if_cloog_tar if_lwip_tar if_gdb_tar
 
 get-$(CURSES): $(TAR_DIR)
 ifeq ($(USE_CURSES),y)
-	make $(CURSES_TAR)
+	$(MAKE) $(CURSES_TAR)
 endif
 
 get-$(ISL): $(TAR_DIR)
 ifeq ($(USE_ISL),y)
-	make $(ISL_TAR)
+	$(MAKE) $(ISL_TAR)
 endif
 
 get-$(CLOOG): $(TAR_DIR)
 ifeq ($(USE_CLOOG),y)
-	make $(CLOOG_TAR)
+	$(MAKE) $(CLOOG_TAR)
 endif
 
 get-$(EXPAT): $(TAR_DIR)
 ifeq ($(USE_EXPAT),y)
-	make $(EXPAT_TAR)
+	$(MAKE) $(EXPAT_TAR)
 endif
 
 get-$(GDB): $(TAR_DIR)
 ifeq ($(USE_GDB),y)
-	make $(GDB_TAR)
+	$(MAKE) $(GDB_TAR)
 endif
 
 get-$(LWIP): $(TAR_DIR)
 ifeq ($(USE_LWIP),y)
-	make $(LWIP_TAR)
+	$(MAKE) $(LWIP_TAR)
 endif
 
 $(SOURCE_DIR):
@@ -573,47 +570,47 @@ build-sdk-libs:  $(SOURCE_DIR)/.$(SDK).installed $(SOURCE_DIR)/.sdk-libs.install
 
 build-$(CURSES): $(TOOLCHAIN)
 ifeq ($(USE_CURSES),y)
-	make $(SOURCE_DIR)/.$(CURSES).installed
+	$(MAKE) $(SOURCE_DIR)/.$(CURSES).installed
 endif
 
 build-$(ISL): $(TOOLCHAIN)
 ifeq ($(USE_ISL),y)
-	make $(SOURCE_DIR)/.$(ISL).installed
+	$(MAKE) $(SOURCE_DIR)/.$(ISL).installed
 endif
 
 build-$(CLOOG): $(TOOLCHAIN)
 ifeq ($(USE_CLOOG),y)
-	make $(SOURCE_DIR)/.$(CLOOG).installed
+	$(MAKE) $(SOURCE_DIR)/.$(CLOOG).installed
 endif
 
 build-$(EXPAT): $(TOOLCHAIN)
 ifeq ($(USE_EXPAT),y)
-	make $(SOURCE_DIR)/.$(EXPAT).installed
+	$(MAKE) $(SOURCE_DIR)/.$(EXPAT).installed
 endif
 
 build-$(GDB): $(TOOLCHAIN)
 ifeq ($(USE_GDB),y)
-	make $(SOURCE_DIR)/.$(GDB).installed
+	$(MAKE) $(SOURCE_DIR)/.$(GDB).installed
 endif
 
 build-$(LWIP): $(TOOLCHAIN)
 ifeq ($(USE_LWIP),y)
-	make $(SOURCE_DIR)/.$(LWIP).installed
+	$(MAKE) $(SOURCE_DIR)/.$(LWIP).installed
 endif
 
 strip:
 ifeq ($(USE_STRIP),y)
-	make $(SOURCE_DIR)/.$(SDK).stripped
+	$(MAKE) $(SOURCE_DIR)/.$(SDK).stripped
 endif
 
 compress:
 ifeq ($(USE_COMPRESS),y)
-	make $(SOURCE_DIR)/.$(SDK).compressed
+	$(MAKE) $(SOURCE_DIR)/.$(SDK).compressed
 endif
 
 distrib:
 ifeq ($(USE_DISTRIB),y)
-	make $(SOURCE_DIR)/.$(SDK).distributed
+	$(MAKE) $(SOURCE_DIR)/.$(SDK).distributed
 endif
 
 #*******************************************
@@ -713,7 +710,7 @@ distrib-info:
 
 $(SOURCE_DIR)/.$(SDK).distributed: $(SOURCE_DIR)/.$(SDK).stripped
 ifeq ($(USE_DISTRIB),y)
-	@$(MAKE_OPT) distrib-info
+	@$(MAKE) distrib-info
 	@$(MKDIR) $(DIST_DIR)
 	-@bsdtar -cz -f $(DIST_DIR)/$(DISTRIB).tar.gz $(TARGET)
 	@ls $(DIST_DIR)/$(DISTRIB)*
@@ -730,7 +727,7 @@ $(SOURCE_DIR)/.$(SDK).extracted: $(SOURCE_DIR)/.$(SDK).loaded
 		-@$(MOVE) $(TOP_SDK)/License $(TOP_SDK)/$(SDK_VER)/
     endif
 $(SOURCE_DIR)/.$(SDK).patched: $(SOURCE_DIR)/.$(SDK).extracted
-	@$(MAKE_OPT) sdk_patch
+	@$(MAKE) sdk_patch
 	@touch $@
 $(SOURCE_DIR)/.$(SDK).installed: $(SOURCE_DIR)/.$(SDK).patched
 	$(RM) $(SOURCE_DIR)/.$(SDK).distributed
@@ -749,14 +746,14 @@ endif
 
 $(SOURCE_DIR)/.sdk-libs.installed: $(TARGET_DIR)/lib/libc.a $(TOOLCHAIN)/bin/xtensa-lx106-elf-gcc
 	$(call Info_Modul,Modify,Libs)
-	@$(MAKE_OPT) libc
+	@$(MAKE) libc
 	$(TOOLCHAIN)/bin/$(XOCP) --rename-section .text=.irom0.text \
 		--rename-section .literal=.irom0.literal $(<) $(TARGET_DIR)/lib/libcirom.a;
 	#@touch $@
 	$(info #### libcirom.a...    ####)
-	@$(MAKE_OPT) libmain
-	@$(MAKE_OPT) libgcc
-	@$(MAKE_OPT) libstdc++
+	@$(MAKE) libmain
+	@$(MAKE) libgcc
+	@$(MAKE) libstdc++
 	@touch $@
 
 libc_objs = lib_a-bzero.o lib_a-memcmp.o lib_a-memcpy.o lib_a-memmove.o lib_a-memset.o lib_a-rand.o \
@@ -815,7 +812,7 @@ endef
 define Config_Modul
 	@echo "##########################"
 	@echo "#### Config $1..."
-	@if ! test -f $(SOURCE_DIR)/.$1.patched; then $(MAKE_OPT) $1_patch && touch $(SOURCE_DIR)/.$1.patched; fi
+	@if ! test -f $(SOURCE_DIR)/.$1.patched; then $(MAKE) $1_patch && touch $(SOURCE_DIR)/.$1.patched; fi
 	@$(MKDIR) $2
 	#### Config: Path=$(SAFEPATH); cd $2 ../$(CONF_OPT) $3 $4
 	PATH=$(SAFEPATH); cd $2; ../$(CONF_OPT) $3 $4 $(QUIET)
@@ -825,8 +822,8 @@ endef
 define Build_Modul
 	@echo "##########################"
 	@echo "#### Build $1..."
-	#### Build: Path=$(SAFEPATH); $3 $(MAKE_OPT) $4 -C $2
-	PATH=$(SAFEPATH); $3 $(MAKE_OPT) $4 -C $2 $(QUIET) 
+	#### Build: Path=$(SAFEPATH); $3 $(MAKE) $4 -C $2
+	PATH=$(SAFEPATH); $3 $(MAKE) $4 -C $2 $(QUIET) 
 	@touch $(SOURCE_DIR)/.$1.builded
 endef
 
@@ -834,8 +831,8 @@ define Install_Modul
 	echo "##########################"
 	echo "#### Install $1..."
 	echo "##########################"
-	#### "Install: Path=$(SAFEPATH); $(MAKE_OPT) $3=$(INST_OPT) -C $2"
-	PATH=$(SAFEPATH); $(MAKE_OPT) $3 -C $2 $(QUIET)
+	#### "Install: Path=$(SAFEPATH); $(MAKE) $3=$(INST_OPT) -C $2"
+	PATH=$(SAFEPATH); $(MAKE) $3 -C $2 $(QUIET)
 	touch $(SOURCE_DIR)/.$1.installed
 	$(OUTPUT_DATE)
 endef
@@ -970,7 +967,7 @@ $(SOURCE_DIR)/.$(NLX).configured: $(SOURCE_DIR)/.$(NLX).extracted
 	$(call Config_Modul,$(NLX),$(BUILD_NLX_DIR),$(NLX_OPT1),--prefix=$(TOOLCHAIN) -target=$(TARGET),$(NLX_OPT))
 $(SOURCE_DIR)/.$(NLX).builded: $(SOURCE_DIR)/.$(NLX).configured
 	$(call Build_Modul,$(NLX),$(BUILD_NLX_DIR),$(NLX_OPT1),all)
-	@$(MAKE_OPT) -C $(BUILD_NLX_DIR) $(QUIET)
+	@$(MAKE) -C $(BUILD_NLX_DIR) $(QUIET)
 $(SOURCE_DIR)/.$(NLX).installed: $(SOURCE_DIR)/.$(NLX).builded
 	$(call Install_Modul,$(NLX),$(BUILD_NLX_DIR),$(INST_OPT))
 
@@ -1076,7 +1073,7 @@ sdk_patch_1.5.2: Patch01_for_ESP8266_NONOS_SDK_V1.5.2.zip
 	@cd $(SDK_DIR)/lib; mkdir -p tmp; cd tmp; $(TOOLCHAIN)/bin/$(XAR) x ../libcrypto.a; cd ..; $(TOOLCHAIN)/bin/$(XAR) rs libwpa.a tmp/*.o; rm -R tmp
 
 sdk_patch:
-	@$(MAKE_OPT) sdk_patch_$(SDK_VERSION)
+	@$(MAKE) sdk_patch_$(SDK_VERSION)
 
 $(GMP)_patch:
 $(MPFR)_patch:
@@ -1161,7 +1158,7 @@ clean-sdk:
 	$(info #### clean-sdk...)
 	$(info ##########################)
 	-rm -rf $(TOP_SDK)
-	-$(MAKE_OPT) -C $(LWIP_DIR) -f Makefile.open clean
+	-$(MAKE) -C $(LWIP_DIR) -f Makefile.open clean
 
 purge: clean
 	$(info ##########################)

--- a/Makefile
+++ b/Makefile
@@ -551,22 +551,15 @@ $(TOOLCHAIN): | $(DIST_DIR) $(SOURCE_DIR) $(TAR_DIR) $(COMP_LIB)
 #************* single targets **************
 #*******************************************
 #
-#build-$(CURSES): $(SOURCE_DIR)/.$(CURSES).installed
-build-$(GMP):    $(SOURCE_DIR)/.$(GMP).installed
-build-$(MPFR):   $(SOURCE_DIR)/.$(GMP).installed $(SOURCE_DIR)/.$(MPFR).installed
-#build-$(ISL):    $(SOURCE_DIR)/.$(GMP).installed $(SOURCE_DIR)/.$(ISL).installed
-#build-$(CLOOG):  $(SOURCE_DIR)/.$(GMP).installed $(SOURCE_DIR)/.$(ISL).installed $(SOURCE_DIR)/.$(CLOOG).installed
-build-$(MPC):    $(SOURCE_DIR)/.$(MPFR).installed $(SOURCE_DIR)/.$(MPC).installed
-#build-$(EXPAT):  $(SOURCE_DIR)/.$(EXPAT).installed
-build-$(BIN):    $(SOURCE_DIR)/.$(MPC).installed $(SOURCE_DIR)/.$(BIN).installed
-build-$(GCC)-1:  $(SOURCE_DIR)/.$(BIN).installed $(SOURCE_DIR)/.$(GCC)-pass-1.installed
-build-$(NLX):    $(SOURCE_DIR)/.$(GCC)-pass-1.installed $(SOURCE_DIR)/.$(NLX).installed
-build-$(GCC)-2:  $(SOURCE_DIR)/.$(NLX).installed $(SOURCE_DIR)/.$(GCC)-pass-2.installed
-build-$(HAL):    $(SOURCE_DIR)/.$(GCC)-pass-2.installed $(SOURCE_DIR)/.$(HAL).installed
-#build-$(GDB):    $(SOURCE_DIR)/.$(GCC)-pass-2.installed $(SOURCE_DIR)/.$(GDB).installed
-#build-$(LWIP):   $(SOURCE_DIR)/.$(LWIP).installed
-###build-$(SDK):    $(SOURCE_DIR)/.$(SDK).installed
-build-sdk-libs:  $(SOURCE_DIR)/.$(SDK).installed $(SOURCE_DIR)/.sdk-libs.installed
+build-$(GMP):    $(SOURCE_DIR)/.$(GMP).installed | $(TOOLCHAIN) 
+build-$(MPFR):   $(SOURCE_DIR)/.$(MPFR).installed | $(TOOLCHAIN) 
+build-$(MPC):    $(SOURCE_DIR)/.$(MPC).installed | $(TOOLCHAIN) 
+build-$(BIN):    $(SOURCE_DIR)/.$(BIN).installed | $(TOOLCHAIN) 
+build-$(GCC)-1:  $(SOURCE_DIR)/.$(GCC)-pass-1.installed | $(TOOLCHAIN) 
+build-$(NLX):    $(SOURCE_DIR)/.$(NLX).installed | $(TOOLCHAIN) 
+build-$(GCC)-2:  $(SOURCE_DIR)/.$(GCC)-pass-2.installed | $(TOOLCHAIN) 
+build-$(HAL):    $(SOURCE_DIR)/.$(HAL).installed | $(TOOLCHAIN) 
+build-sdk-libs:  $(SOURCE_DIR)/.$(SDK).installed $(SOURCE_DIR)/.sdk-libs.installed | $(TOOLCHAIN)
 
 build-$(CURSES): | $(TOOLCHAIN)
 ifeq ($(USE_CURSES),y)
@@ -866,7 +859,7 @@ $(SOURCE_DIR)/.$(MPFR).loaded:
 	$(call Load_Modul,$(MPFR),$(MPFR_URL),$(MPFR_TAR))
 $(SOURCE_DIR)/.$(MPFR).extracted: $(SOURCE_DIR)/.$(MPFR).loaded
 	$(call Extract_Modul,$(MPFR),$(MPFR_DIR),$(MPFR_TAR),$(MPFR_DIR)/$(MPFR_TAR_DIR))
-$(SOURCE_DIR)/.$(MPFR).configured: $(SOURCE_DIR)/.$(MPFR).extracted
+$(SOURCE_DIR)/.$(MPFR).configured: $(SOURCE_DIR)/.$(MPFR).extracted $(SOURCE_DIR)/.$(GMP).installed
 	$(call Config_Modul,$(MPFR),$(BUILD_MPFR_DIR),--prefix=$(COMP_LIB)/$(MPFR)-$(MPFR_VERSION) -with-$(GMP)=$(COMP_LIB)/$(GMP)-$(GMP_VERSION),$(MPFR_OPT))
 $(SOURCE_DIR)/.$(MPFR).builded: $(SOURCE_DIR)/.$(MPFR).configured
 	$(call Build_Modul,$(MPFR),$(BUILD_MPFR_DIR))
@@ -878,7 +871,7 @@ $(SOURCE_DIR)/.$(MPC).loaded:
 	$(call Load_Modul,$(MPC),$(MPC_URL),$(MPC_TAR))
 $(SOURCE_DIR)/.$(MPC).extracted: $(SOURCE_DIR)/.$(MPC).loaded
 	$(call Extract_Modul,$(MPC),$(MPC_DIR),$(MPC_TAR),$(MPC_DIR)/$(MPC_TAR_DIR))
-$(SOURCE_DIR)/.$(MPC).configured: $(SOURCE_DIR)/.$(MPC).extracted
+$(SOURCE_DIR)/.$(MPC).configured: $(SOURCE_DIR)/.$(MPC).extracted $(SOURCE_DIR)/.$(GMP).installed $(SOURCE_DIR)/.$(MPFR).installed
 	$(call Config_Modul,$(MPC),$(BUILD_MPC_DIR),--prefix=$(COMP_LIB)/$(MPC)-$(MPC_VERSION) -with-$(MPFR)=$(COMP_LIB)/$(MPFR)-$(MPFR_VERSION) -with-$(GMP)=$(COMP_LIB)/$(GMP)-$(GMP_VERSION),$(MPC_OPT))
 $(SOURCE_DIR)/.$(MPC).builded: $(SOURCE_DIR)/.$(MPC).configured
 	$(call Build_Modul,$(MPC),$(BUILD_MPC_DIR))
@@ -914,7 +907,7 @@ $(SOURCE_DIR)/.$(ISL).loaded:
 	$(call Load_Modul,$(ISL),$(ISL_URL),$(ISL_TAR))
 $(SOURCE_DIR)/.$(ISL).extracted: $(SOURCE_DIR)/.$(ISL).loaded
 	$(call Extract_Modul,$(ISL),$(ISL_DIR),$(ISL_TAR),$(ISL_DIR)/$(ISL_TAR_DIR))
-$(SOURCE_DIR)/.$(ISL).configured: $(SOURCE_DIR)/.$(ISL).extracted
+$(SOURCE_DIR)/.$(ISL).configured: $(SOURCE_DIR)/.$(ISL).extracted $(SOURCE_DIR)/.$(GMP).installed
 	$(call Config_Modul,$(ISL),$(BUILD_ISL_DIR),--prefix=$(COMP_LIB)/$(ISL)-$(ISL_VERSION),$(ISL_OPT))
 $(SOURCE_DIR)/.$(ISL).builded: $(SOURCE_DIR)/.$(ISL).configured
 	$(call Build_Modul,$(ISL),$(BUILD_ISL_DIR))
@@ -926,7 +919,7 @@ $(SOURCE_DIR)/.$(CLOOG).loaded:
 	$(call Load_Modul,$(CLOOG),$(CLOOG_URL),$(CLOOG_TAR))
 $(SOURCE_DIR)/.$(CLOOG).extracted: $(SOURCE_DIR)/.$(CLOOG).loaded
 	$(call Extract_Modul,$(CLOOG),$(CLOOG_DIR),$(CLOOG_TAR),$(CLOOG_DIR)/$(CLOOG_TAR_DIR))
-$(SOURCE_DIR)/.$(CLOOG).configured: $(SOURCE_DIR)/.$(CLOOG).extracted
+$(SOURCE_DIR)/.$(CLOOG).configured: $(SOURCE_DIR)/.$(CLOOG).extracted $(SOURCE_DIR)/.$(GMP).installed $(SOURCE_DIR)/.$(ISL).installed
 	$(call Config_Modul,$(CLOOG),$(BUILD_CLOOG_DIR),--prefix=$(COMP_LIB)/$(CLOOG)-$(CLOOG_VERSION),$(CLOOG_OPT))
 $(SOURCE_DIR)/.$(CLOOG).builded: $(SOURCE_DIR)/.$(CLOOG).configured
 	$(call Build_Modul,$(CLOOG),$(BUILD_CLOOG_DIR))

--- a/Makefile
+++ b/Makefile
@@ -826,9 +826,9 @@ define Build_Modul
 endef
 
 define Install_Modul
-	echo "##########################"
-	echo "#### Install $1..."
-	echo "##########################"
+	@echo "##########################"
+	@echo "#### Install $1..."
+	@echo "##########################"
 	#### "Install: Path=$(SAFEPATH); $(MAKE) $3=$(INST_OPT) -C $2"
 	PATH=$(SAFEPATH); $(MAKE) $3 -C $2 $(QUIET)
 	touch $(SOURCE_DIR)/.$1.installed

--- a/Makefile
+++ b/Makefile
@@ -485,7 +485,7 @@ install:
 #*******************************************
 
 build: build-bins build-$(GCC)-1 build-$(NLX) build-$(GCC)-2 build-$(HAL) build-sdk-libs
-build-bins: $(TOOLCHAIN) build-$(CURSES) build-$(GMP) build-$(MPFR) build-$(ISL) build-$(CLOOG) build-$(MPC) build-$(EXPAT) build-$(BIN)
+build-bins: build-$(CURSES) build-$(GMP) build-$(MPFR) build-$(ISL) build-$(CLOOG) build-$(MPC) build-$(EXPAT) build-$(BIN)
 ###build-sdk: build-$(SDK) build-sdk-libs
 ###build-sdk: build-sdk-libs
 build-tools: build-$(GDB) build-$(LWIP) distrib #strip compress
@@ -543,7 +543,7 @@ $(COMP_LIB):
 $(DIST_DIR):
 	@$(MKDIR) $(DIST_DIR)
 
-$(TOOLCHAIN): $(DIST_DIR) $(SOURCE_DIR) $(TAR_DIR) $(COMP_LIB)
+$(TOOLCHAIN): | $(DIST_DIR) $(SOURCE_DIR) $(TAR_DIR) $(COMP_LIB)
 	@git config --global core.autocrlf false
 	@$(MKDIR) $(TOOLCHAIN)
 
@@ -568,32 +568,32 @@ build-$(HAL):    $(SOURCE_DIR)/.$(GCC)-pass-2.installed $(SOURCE_DIR)/.$(HAL).in
 ###build-$(SDK):    $(SOURCE_DIR)/.$(SDK).installed
 build-sdk-libs:  $(SOURCE_DIR)/.$(SDK).installed $(SOURCE_DIR)/.sdk-libs.installed
 
-build-$(CURSES): $(TOOLCHAIN)
+build-$(CURSES): | $(TOOLCHAIN)
 ifeq ($(USE_CURSES),y)
 	$(MAKE) $(SOURCE_DIR)/.$(CURSES).installed
 endif
 
-build-$(ISL): $(TOOLCHAIN)
+build-$(ISL): | $(TOOLCHAIN)
 ifeq ($(USE_ISL),y)
 	$(MAKE) $(SOURCE_DIR)/.$(ISL).installed
 endif
 
-build-$(CLOOG): $(TOOLCHAIN)
+build-$(CLOOG): | $(TOOLCHAIN)
 ifeq ($(USE_CLOOG),y)
 	$(MAKE) $(SOURCE_DIR)/.$(CLOOG).installed
 endif
 
-build-$(EXPAT): $(TOOLCHAIN)
+build-$(EXPAT): | $(TOOLCHAIN)
 ifeq ($(USE_EXPAT),y)
 	$(MAKE) $(SOURCE_DIR)/.$(EXPAT).installed
 endif
 
-build-$(GDB): $(TOOLCHAIN)
+build-$(GDB): | $(TOOLCHAIN)
 ifeq ($(USE_GDB),y)
 	$(MAKE) $(SOURCE_DIR)/.$(GDB).installed
 endif
 
-build-$(LWIP): $(TOOLCHAIN)
+build-$(LWIP): | $(TOOLCHAIN)
 ifeq ($(USE_LWIP),y)
 	$(MAKE) $(SOURCE_DIR)/.$(LWIP).installed
 endif
@@ -758,7 +758,7 @@ $(SOURCE_DIR)/.sdk-libs.installed: $(TARGET_DIR)/lib/libc.a $(TOOLCHAIN)/bin/xte
 
 libc_objs = lib_a-bzero.o lib_a-memcmp.o lib_a-memcpy.o lib_a-memmove.o lib_a-memset.o lib_a-rand.o \
 		lib_a-strcmp.o lib_a-strcpy.o lib_a-strlen.o lib_a-strncmp.o lib_a-strncpy.o lib_a-strstr.o
-libc: $(TARGET_DIR)/lib/libc.a $(TOOLCHAIN) $(NLX_DIR)
+libc: $(TARGET_DIR)/lib/libc.a | $(TOOLCHAIN) $(NLX_DIR)
 	$(TOOLCHAIN)/bin/$(XAR) $(AR_DEL) $(TARGET_DIR)/lib/$@.a $(libc_objs)
 	$(info #### libc.a ...       ####)
 
@@ -1137,7 +1137,7 @@ Patch01_for_ESP8266_NONOS_SDK_V1.5.2.zip:
 ESP8266_NONOS_SDK_V2.0.0_patch_16_08_09.zip:
 	@$(WGET) --content-disposition "http://bbs.espressif.com/download/file.php?id=1654" --output-document $(PATCHES_DIR)/$@
 
-$(SDK_DIR)/user_rf_cal_sector_set.o: $(SDK_DIR) $(TOOLCHAIN)/bin/$(XGCC)
+$(SDK_DIR)/user_rf_cal_sector_set.o: $(SOURCE_DIR)/.$(SDK).extracted $(TOOLCHAIN)/bin/$(XGCC)
 	@cp -p $(PATCHES_DIR)/user_rf_cal_sector_set.c $(SDK_DIR)
 	@cd $(SDK_DIR); $(TOOLCHAIN)/bin/$(XGCC) -O2 -I$(SDK_DIR)/include -c $(SDK_DIR)/user_rf_cal_sector_set.c
 

--- a/Makefile
+++ b/Makefile
@@ -742,11 +742,11 @@ endif
 #*************** LIBs section **************
 #*******************************************
 
-$(SOURCE_DIR)/.sdk-libs.installed: $(TARGET_DIR)/lib/libc.a $(TOOLCHAIN)/bin/xtensa-lx106-elf-gcc
+$(SOURCE_DIR)/.sdk-libs.installed: $(SOURCE_DIR)/.$(SDK).installed
 	$(call Info_Modul,Modify,Libs)
 	@$(MAKE) libc
 	$(TOOLCHAIN)/bin/$(XOCP) --rename-section .text=.irom0.text \
-		--rename-section .literal=.irom0.literal $(<) $(TARGET_DIR)/lib/libcirom.a;
+		--rename-section .literal=.irom0.literal $(TARGET_DIR)/lib/libc.a $(TARGET_DIR)/lib/libcirom.a;
 	#@touch $@
 	$(info #### libcirom.a...    ####)
 	@$(MAKE) libmain

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,9 @@ install:
   
 build_script:
 #run command via bash --login to have all env variables set up
-  - C:\msys64\usr\bin\bash --login -c "make"
-
+  - C:\msys64\usr\bin\bash --login -c "echo Build using $(expr $(nproc) + 1) jobs"
+  - C:\msys64\usr\bin\bash --login -c "make --debug=b -j$(expr $(nproc) + 1)"
+  
 on_failure:
   - ECHO Printing distrib\MinGW64-error.log...
   - TYPE distrib\MinGW64-error.log

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,23 +1,22 @@
 image: Visual Studio 2017
 
 environment:
-  matrix:
-  - MSYSTEM: MSYS
-    LOG_NAME: MSYS64
-  - MSYSTEM: MINGW64
-    LOG_NAME: MINGW64_NT-10.0
-
+#use MINGW64 environment to have native WIndows  binaries
+  MSYSTEM: MINGW64 
+#run bash without changing current directory
+  CHERE_INVOKING: 1
+  
 install:
-  - SET PATH=%PATH:C:\Program Files\Git\usr\bin;=%
-  - SET PATH=C:\msys64\usr\bin;%PATH%
+  - C:\msys64\usr\bin\bash --login -c "pacman --needed --noconfirm -S texinfo autoconf automake mingw-w64-x86_64-make mingw-w64-x86_64-gcc"
   
 build_script:
-  - make
+#run command via bash --login to have all env variables set up
+  - C:\msys64\usr\bin\bash --login -c "make"
 
 on_failure:
-  - ECHO Printing distrib\%LOG_NAME%-error.log...
-  - TYPE distrib\%LOG_NAME%-error.log
-  
+  - ECHO Printing distrib\MinGW64-error.log...
+  - TYPE distrib\MinGW64-error.log
+
 notifications:
   - provider: Email
     on_build_success: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ install:
 build_script:
 #run command via bash --login to have all env variables set up
   - C:\msys64\usr\bin\bash --login -c "echo Build using $(expr $(nproc) + 1) jobs"
-  - C:\msys64\usr\bin\bash --login -c "make --debug=b -j$(expr $(nproc) + 1)"
+  - C:\msys64\usr\bin\bash --login -c "make -j$(expr $(nproc) + 1)"
   
 on_failure:
   - ECHO Printing distrib\MinGW64-error.log...


### PR DESCRIPTION
Here are changes that allows building this project with paralellisation (-j n). This was needed to make MinGW64 build possible on appveyor, but also this is nice feature that allows much faster change-build cycle.  Additional benefit is simplified osx build.

I was trying to be explicit on commit messages and I'm open to any questions and suggestions.
I have still some changes related to some additional clean-ups, deployment and tool target, but I will leave that for later, if this PR well be accepted.
