### PR TITLE
Travis and appveyor badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Travis Build Status](https://travis-ci.org/Juppit/esp-new-sdk.svg?branch=master)](https://travis-ci.org/Juppit/esp-new-sdk)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/Juppit/esp-new-sdk?svg=true)](https://ci.appveyor.com/project/Juppit/esp-new-sdk))
 # esp-new-sdk
 
 Makefile to build the toolchain and a complete standalone SDK for Espressif ESP8266.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Travis Build Status](https://travis-ci.org/Juppit/esp-new-sdk.svg?branch=master)](https://travis-ci.org/Juppit/esp-new-sdk)
-[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/Juppit/esp-new-sdk?svg=true)](https://ci.appveyor.com/project/Juppit/esp-new-sdk))
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/Juppit/esp-new-sdk?svg=true)](https://ci.appveyor.com/project/Juppit/esp-new-sdk)
 # esp-new-sdk
 
 Makefile to build the toolchain and a complete standalone SDK for Espressif ESP8266.


### PR DESCRIPTION
Just bells and whistles.
You can check here how it looks:
https://github.com/vanklompf/esp-new-sdk/tree/continous_integration_work

I wanted to have separate status for Linux and Mac build on travis, but either I don't know how or it's impossible.


